### PR TITLE
fix the runtime bug caused by the absence of a return value in a non-…

### DIFF
--- a/lib/LwM2m/LwM2mManager.cpp
+++ b/lib/LwM2m/LwM2mManager.cpp
@@ -195,6 +195,7 @@ bool LwM2mManager::init()
   fprintf(stdout, "LWM2M Client \"%s\" started on port %s\r\n", name, localPort);
   fprintf(stdout, "> ");
   fflush(stdout);
+  return true;
   /*
      * We now enter in a while loop that will handle the communications from the server
      */


### PR DESCRIPTION
…void function.

The statement "return true" is essential for the following two reasons:
1. It is considered good programming practice to provide a default value for a non-void function, which helps avoid warnings from the compiler.
2. Additionally, the absence of a return statement in a non-void function can cause an undefined error. In this particular example, the lack of a return statement would always result in a null pointer error. Consequently, an infinite loop setup() would occur. More detailed reasons are explained as follows:

After disassembling firmware.elf, it was discovered that the compiler erroneously placed the assembly instruction corresponding to the code following the "else if" statement at the end of the init function. This issue is likely a bug in the RISC-V GCC compiler when there is no "else" clause following an "if...else if" structure. Therefore, adding a return statement at the end of the function can prevent the execution of additional disassembly instructions that may lead to a null pointer error.